### PR TITLE
Add prettier and eslint checks to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,12 @@ jobs:
             - client/node_modules
           key: v1-dependencies-{{ checksum "client/package.json" }}
         
+      # check prettier
+      - run: cd client && npm run check-pretty
+
+      # check linting
+      - run: cd client && npm run lint
+
       # run tests!
       - run: cd client && npm test
 

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
     "watch": "jest --watch --verbose=false",
     "coverage": "jest --coverage --coverageDirectory=coverage",
     "pretty": "prettier --write 'app/**/*.js'",
+    "check-pretty": "prettier --list-different 'app/**/*.js'",
     "lint": "eslint 'app/**/*.js'"
   },
   "dependencies": {


### PR DESCRIPTION
Note:
new npm command: `npm run check-pretty` checks if the client-side project is already prettified.